### PR TITLE
Fix typo that caused invalid JSON in Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,7 +3,7 @@
 module.exports = function (grunt) {
   grunt.initConfig({
     nodeunit: {
-      files: ['test/**/*_test.js'],
+      files: ['test/**/*_test.js']
     },
     jshint: {
       options: {


### PR DESCRIPTION
Fix typo that caused invalid JSON in Gruntfile.js
