### PR TITLE
Update devDependencies / Fix JSHint seting

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,6 +11,5 @@
   "boss": true,
   "eqnull": true,
   "node": true,
-  "es5": true,
   "laxbreak": true
 }

--- a/package.json
+++ b/package.json
@@ -38,9 +38,10 @@
     "grunt": "~0.4.0"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-nodeunit": "~0.1.2",
-    "grunt-contrib-watch": "~0.2.0"
+    "grunt-contrib-jshint": "~0.8.0",
+    "grunt-contrib-nodeunit": "~0.3.0",
+    "grunt-contrib-watch": "~0.5.3",
+    "grunt": "~0.4.2"
   },
   "dependencies": {
     "wiredep": "~0.5.0",


### PR DESCRIPTION
I updated devDependencies of this project and fixed JSHint setting. Now there is no need to set the "ES5" option explicitly. (cf. http://www.jshint.com/blog/2013-05-07/2-0-0/).
