### PR TITLE
Bump wiredep version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grunt": "~0.4.0"
   },
   "dependencies": {
-    "wiredep": "~1.5.0",
+    "wiredep": "~1.7.3",
     "bower-config": "~0.5.0"
   }
 }


### PR DESCRIPTION
Depend on a newer wiredep version (~1.7.3).
