### PR TITLE
add main field to package.json to set module entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "component",
     "postinstall"
   ],
+  "main": "tasks/wiredep",
   "repository": "stephenplusplus/grunt-wiredep",
   "licenses": [
     {


### PR DESCRIPTION
It is a best practise to define the entry point of the module in the package.json file.
Using this module will be done by `require('grunt-wiredep')` instead of `require('grunt-wiredep/tasks/wiredep.js')`.